### PR TITLE
Fix/remove implicit waiting

### DIFF
--- a/src/main/java/pages/BasePage.java
+++ b/src/main/java/pages/BasePage.java
@@ -12,7 +12,6 @@ public class BasePage {
     protected final By pageHeader =  By.cssSelector("[data-test='title']");
     protected ElementChecker checkElement;
     private final String pathUrl;
-    private String pageHeaderText;
     Logger logger = Logger.getLogger(getClass().getName());
 
     // Set the driver, pathUrl and pass the driver to the elementChecker object.
@@ -28,7 +27,7 @@ public class BasePage {
     public boolean isPageValid(String baseUrl, String pageHeaderText) {
         String expectedUrl = baseUrl + getPath();
         String currentUrl = driver.getCurrentUrl();
-        this.pageHeaderText = pageHeaderText;
+        String pageHeaderText = pageHeaderText;
 
         boolean isDisplayed = checkElement.elementExists(pageHeader);
         boolean hasExpectedText = checkElement.textMatches(pageHeader, pageHeaderText);

--- a/src/main/java/pages/BasePage.java
+++ b/src/main/java/pages/BasePage.java
@@ -20,7 +20,6 @@ public class BasePage {
         this.driver = driver;
         this.pathUrl = pathUrl;
         checkElement = new ElementChecker(this.driver);
-        driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(2));
     }
     public boolean isHeaderTextDisplayed() { return checkElement.elementExists(pageHeader); }
 

--- a/src/main/java/pages/BasePage.java
+++ b/src/main/java/pages/BasePage.java
@@ -3,8 +3,6 @@ package pages;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import util.ElementChecker;
-
-import java.time.Duration;
 import java.util.logging.Logger;
 
 public class BasePage {
@@ -27,7 +25,6 @@ public class BasePage {
     public boolean isPageValid(String baseUrl, String pageHeaderText) {
         String expectedUrl = baseUrl + getPath();
         String currentUrl = driver.getCurrentUrl();
-        String pageHeaderText = pageHeaderText;
 
         boolean isDisplayed = checkElement.elementExists(pageHeader);
         boolean hasExpectedText = checkElement.textMatches(pageHeader, pageHeaderText);


### PR DESCRIPTION
- Removed the implicit wait from the BasePage being used by 3 tests.
-  Cleaned up BasePage's instance variable reference and moved it to local scope.
- Remove the unused Duration import left behind by using Implicit Wait. This was removed during this PR.